### PR TITLE
stable label color improvement

### DIFF
--- a/MacBox/Storyboards/Base.lproj/Main.storyboard
+++ b/MacBox/Storyboards/Base.lproj/Main.storyboard
@@ -1326,7 +1326,7 @@
                                                     <textFieldCell key="cell" lineBreakMode="clipping" allowsUndo="NO" alignment="center" title="Stable" drawsBackground="YES" usesSingleLineMode="YES" id="RSq-qQ-pZk">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        <color key="backgroundColor" name="systemGreenColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" red="0.28379482301058628" green="0.55913740335051543" blue="0.24757867575325401" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                     </textFieldCell>
                                                 </textField>
                                                 <customView focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="oXg-3g-bvZ" userLabel="SpacerView">


### PR DESCRIPTION
I prepared a little UI improvement for your consideration :) The label for 86box branch for 'Stable' in my opinion was too bright and white text was hard to see so I just changed it to a little darker.

before :
<img width="209" alt="Zrzut ekranu 2024-04-23 o 22 07 05" src="https://github.com/Moonif/MacBox/assets/22888465/6585fe08-5508-404f-ad32-378daaf6628d">

after :
<img width="154" alt="Zrzut ekranu 2024-04-23 o 22 07 52" src="https://github.com/Moonif/MacBox/assets/22888465/cb6fa13c-4d9a-4492-be05-56754432e93f">


