### PR TITLE
Don't add percent-encoding to path when creating/adding a VM

### DIFF
--- a/MacBox/ViewControllers/MainViewController.swift
+++ b/MacBox/ViewControllers/MainViewController.swift
@@ -682,7 +682,7 @@ class MainViewController: NSViewController {
                 defaultPath = homeDirURL.appendingPathComponent(UUID().uuidString)
             }
             
-            fixedVM.path = defaultPath.path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
+            fixedVM.path = defaultPath.path
         }
         
         // Create all VM paths


### PR DESCRIPTION
Fixes issue #39 by not adding percent encoding to the path when creating a VM.