### PR TITLE
Fix the HDD controller type in the Amstrad PC1512

### DIFF
--- a/MacBox/Templates/amstrd_pc1512/86box.cfg
+++ b/MacBox/Templates/amstrd_pc1512/86box.cfg
@@ -8,7 +8,7 @@ cpu_speed = 8000000
 mem_size = 512
 
 [Storage controllers]
-hdc = st506_xt_gen
+hdc = st506_xt_dtc5150x
 
 [Input devices]
 mouse_type = internal


### PR DESCRIPTION
The WDXT-GEN has a hardcoded 30 MB drive type
The DTC can be configured for a 10 MB ST-212 drive from the format utility (debug -g=c800:5)