### PR TITLE
Fix HDD controller type and CHS values for Compaq Portable 386

### DIFF
--- a/MacBox/Templates/cpq_portable_386/86box.cfg
+++ b/MacBox/Templates/cpq_portable_386/86box.cfg
@@ -10,13 +10,7 @@ fpu_type = 387
 mem_size = 1024
 
 [Storage controllers]
-hdc = st506_xt_st11_r
-
-[ST-11R RLL Fixed Disk Adapter]
-base = 0320
-irq = 5
-bios_addr = C8000
-revision = 5
+hdc = st506_at
 
 [Input devices]
 mouse_type = mssystems
@@ -36,7 +30,7 @@ composite_type = 0
 rgb_type = 2
 
 [Hard disks]
-hdd_01_parameters = 17, 8, 615, 0, mfm
+hdd_01_parameters = 17, 6, 805, 0, mfm
 hdd_01_mfm_channel = 0
 hdd_01_fn = disks/hdd.IMG
 


### PR DESCRIPTION
In the BIOS setup, the drive type is 22