### PR TITLE
IBM PS/1 Model 2011 fixes

### DIFF
--- a/MacBox/Templates/ibm_ps1es/86box.cfg
+++ b/MacBox/Templates/ibm_ps1es/86box.cfg
@@ -7,9 +7,6 @@ mem_size = 512
 cpu_use_dynarec = 0
 time_sync = disabled
 
-[Storage controllers]
-hdc = st506_xt_dtc5150x
-
 [Input devices]
 mouse_type = ps2
 
@@ -26,17 +23,10 @@ gfxcard = internal
 fm_driver = nuked
 
 [Hard disks]
-hdd_01_parameters = 17, 6, 615, 0, mfm
+hdd_01_parameters = 33, 2, 921, 0, xta
 hdd_01_mfm_channel = 0
 hdd_01_fn = disks/hdd.IMG
 
 [Floppy and CD-ROM drives]
-fdd_01_type = 35_2hd_ps2
+fdd_01_type = 35_2hd
 fdd_02_type = none
-
-[IBM PC/XT Memory Expansion #1]
-size = 512
-start = 256
-
-[Other peripherals]
-isamem0_type = ibmxt

--- a/MacBox/Templates/ibm_ps1es/86box.cfg
+++ b/MacBox/Templates/ibm_ps1es/86box.cfg
@@ -24,7 +24,7 @@ fm_driver = nuked
 
 [Hard disks]
 hdd_01_parameters = 33, 2, 921, 0, xta
-hdd_01_mfm_channel = 0
+hdd_01_xta_channel = 0
 hdd_01_fn = disks/hdd.IMG
 
 [Floppy and CD-ROM drives]


### PR DESCRIPTION
Fix HDD controller type and drive geometry, as well as remove the incompatible PC/XT memory expansion
Also, the PS/2 specific floppy drive was merged with the normal one in later 86Box releases