### PR TITLE
PS/1 Model 2121 fixes

### DIFF
--- a/MacBox/Templates/ibm_ps1_2121/86box.cfg
+++ b/MacBox/Templates/ibm_ps1_2121/86box.cfg
@@ -1,7 +1,7 @@
 [Machine]
 machine = ibmps1_2121
 cpu_family = i386sx
-cpu_speed = 16000000
+cpu_speed = 20000000
 cpu_multi = 1
 cpu_use_dynarec = 0
 time_sync = disabled
@@ -21,7 +21,6 @@ serial2_enabled = 0
 
 [Video]
 gfxcard = internal
-8514a = 1
 
 [Sound]
 fm_driver = nuked
@@ -33,5 +32,5 @@ hdd_01_speed = 1989_3500rpm
 hdd_01_ide_channel = 0:0
 
 [Floppy and CD-ROM drives]
-fdd_01_type = 35_2hd_ps2
+fdd_01_type = 35_2hd
 fdd_02_type = none


### PR DESCRIPTION
Change clock speed to 20 MHz, as the BIOS in 86Box is from the 20 MHz variant (no DOS in ROM), also disable 8514/A, as it's not applicable to the real machine, and change the floppy type to a normal 3,5" drive, as the PS/2 specific one got merged with the regular one in later 86Box update