### PR TITLE
Tandy 1000 (SX) fixes

### DIFF
--- a/MacBox/Templates/tndy_1000/86box.cfg
+++ b/MacBox/Templates/tndy_1000/86box.cfg
@@ -1,11 +1,11 @@
 [Machine]
 machine = tandy
-cpu_family = 8088_europc
-cpu_speed = 4772728
+cpu_family = 8088
+cpu_speed = 7159092
 cpu_multi = 1
 cpu_use_dynarec = 0
 time_sync = disabled
-mem_size = 128
+mem_size = 640
 
 [Video]
 gfxcard = internal

--- a/MacBox/Templates/tndy_1000/macbox.inf
+++ b/MacBox/Templates/tndy_1000/macbox.inf
@@ -1,8 +1,8 @@
 [General]
 Manufacturer=Tandy
-Description=Tandy 1000
+Description=Tandy 1000 SX
 Logo=Tandy_logo
-Year=1984
+Year=1987
 Author=Moonif
 
 [Shader]


### PR DESCRIPTION
The Tandy 1000 BIOS was discovered to be actually for the 1000 SX, so adjust the CPU clock and RAM size to match a real Tandy 1000 SX, also, update the description