### PR TITLE
Fix the CHS values and add a Microsoft Serial Mouse to the Compaq Deskpro template

### DIFF
--- a/MacBox/Templates/cpq_deskpro/86box.cfg
+++ b/MacBox/Templates/cpq_deskpro/86box.cfg
@@ -11,7 +11,7 @@ mem_size = 256
 hdc = st506_xt_dtc5150x
 
 [Input devices]
-mouse_type = none
+mouse_type = msserial
 
 [Ports (COM & LPT)]
 serial2_enabled = 0
@@ -29,6 +29,6 @@ rgb_type = 2
 snow_enabled = 1
 
 [Hard disks]
-hdd_01_parameters = 17, 8, 306, 0, mfm
+hdd_01_parameters = 17, 4, 306, 0, mfm
 hdd_01_fn = disks/hdd.IMG
 hdd_01_mfm_channel = 0


### PR DESCRIPTION
Change the CHS values to the ones supported by the built-in format utility of the DTC MFM controller (corresponding to the ST-212 HDD), also add a Microsoft Serial Mouse, which is handy for many users
Although the new values result in a smaller HDD, MS-DOS 2.12 (which shipped with this model) could not make full use of bigger disks reliably