### PR TITLE
Correct internal name for Tandy 1000 SX

### DIFF
--- a/MacBox/Templates/tndy_1000/86box.cfg
+++ b/MacBox/Templates/tndy_1000/86box.cfg
@@ -1,5 +1,5 @@
 [Machine]
-machine = tandy
+machine = tandy1000sx
 cpu_family = 8088
 cpu_speed = 7159092
 cpu_multi = 1


### PR DESCRIPTION
It was changed in 86Box build 7224