### PR TITLE
Remove the HDD controller from the HDD-less Compaq Portable Template

### DIFF
--- a/MacBox/Templates/cpq_portable/86box.cfg
+++ b/MacBox/Templates/cpq_portable/86box.cfg
@@ -7,9 +7,6 @@ time_sync = disabled
 cpu_speed = 4772728
 mem_size = 128
 
-[Storage controllers]
-hdc = st506_xt_dtc5150x
-
 [Input devices]
 mouse_type = none
 


### PR DESCRIPTION
reduces boot time and removes POST errors